### PR TITLE
Fixed typo in use of && and ||.

### DIFF
--- a/DemoApp/DemoApp.ino
+++ b/DemoApp/DemoApp.ino
@@ -93,7 +93,7 @@ void Send_Sensors(){
   Serial.print("Acc Z: "); Serial.println((float)z_g.number/250);
   free(xyz_g);
 
-  int payloadSize = 12; //in byte
+  const uint8_t payloadSize = 12; //in bytes
 //  byte* buf_str = (byte*) malloc (payloadSize);
   uint8_t buf_str[payloadSize];
 
@@ -143,7 +143,7 @@ void getDLMsg(){
 }
 
 
-void Send_Pload(uint8_t *sendData, int len){
+void Send_Pload(uint8_t *sendData, const uint8_t len){
   // No downlink message require
   recvMsg *RecvMsg;
   Isigfox->resetMacroChannel(); // required to send on first macro channel
@@ -151,7 +151,7 @@ void Send_Pload(uint8_t *sendData, int len){
 
   RecvMsg = (recvMsg *)malloc(sizeof(recvMsg));
   Isigfox->sendPayload(sendData, len, 0, RecvMsg);
-  for (int i=0; i<RecvMsg->len; i++){
+  for (int i = 0; i < RecvMsg->len; i++) {
     Serial.print(RecvMsg->inData[i]);
   }
   Serial.println("");

--- a/libraries/Isigfox/Isigfox.h
+++ b/libraries/Isigfox/Isigfox.h
@@ -71,12 +71,12 @@ public:
     /** Send a Sigfox frame
     	@param outData					a pointer to an array of bytes to send
     	@param len						[0...12], the length of the array of bytes to send
-		@param donwlink					0, no downlink message required or 1, downlink message required. Other valid are invalid.
+		@param donwlink					0, no downlink message required or 1, downlink message required. Other values are invalid.
 		@param recvMsg *receivedMsg		pointer on recMsg structure. if NULL or not used, the function will not block until Sigfox module’s answer reception.
 		@return							0 if succeed and -1, otherwise
     */
-	virtual int sendPayload(uint8_t *outData, int len, int downlink, recvMsg *receivedMsg) = 0;
-	virtual int sendPayload(uint8_t *outData, int len, int downlink) = 0;
+	virtual int sendPayload(uint8_t *outData, const uint8_t len, int downlink, recvMsg *receivedMsg) = 0;
+	virtual int sendPayload(uint8_t *outData, const uint8_t len, int downlink) = 0;
 
 
     /** Send a command to the Sigfox module
@@ -107,17 +107,17 @@ public:
     */
     virtual int setZone() = 0;
 
-		/** Set the AES Key to public value in order to use SNEK dongle
+	/** Set the AES Key to public value in order to use SNEK dongle
 	@return			0
-		*/
-		virtual int setPublicKey() = 0;
+	*/
+	virtual int setPublicKey() = 0;
 
-		/** Set the AES Key to default private value to use on sigfox network
-	@return			0
+	/** Set the AES Key to default private value to use on sigfox network
+    @return			0
     */
     virtual int setPrivateKey() = 0;
 
-		/** Reset the FCC Macro Channel
+	/** Reset the FCC Macro Channel
 	@return			0
     */
     virtual int resetMacroChannel() = 0;

--- a/libraries/Isigfox/WISOL.cpp
+++ b/libraries/Isigfox/WISOL.cpp
@@ -17,10 +17,9 @@ void WISOL::configIO(pinIO pin){
 
 /*
 int init()
-	- Output: return 0 if init succesfully. Return 1 if otherwise.
+	- Output: return 0 if init succesfully. Return 1 otherwise.
 	- Purpose: Init Serial and set UL Frequency to 920.8 MHz
 */
-
 int WISOL::initSigfox(){
 	// Init Serial
 	Serial.begin(9600);
@@ -46,11 +45,11 @@ int WISOL::initSigfox(){
 		{
 			Serial.println("No zone");
 			clearBuffer();
-			return -1;
+			return 1;
 		}
 	}
 	clearBuffer();
-	return 1;
+	return 0;
 }
 
 int WISOL::setPublicKey() {
@@ -132,7 +131,7 @@ int WISOL::setZone(){
 	return -1;
 }
 
-void WISOL::printRecv(char *in, int len){
+void WISOL::printRecv(char *in, int len) {
 	for (int i=0; i<len; i++){
 		Serial.print(in[i]);
 	}
@@ -154,7 +153,7 @@ int WISOL::strCmp(char *in1, char *in2, int len){
 int testComms()
  - Send "AT" and wait for "OK" back
  - Return 0 if testing succesfully (receive "1234" back)
- - Return 1 otherwise
+ - Return -1 otherwise
 */
 int WISOL::testComms(){
 	static char testchar[] = "AT";
@@ -170,7 +169,7 @@ int WISOL::testComms(){
 		return -1;
 	}
 
-	if (receivedMsg->inData[0]=='O' && receivedMsg->inData[1]=='K'){
+	if (receivedMsg->inData[0] == 'O' && receivedMsg->inData[1] == 'K'){
 		return 0;
 	} else {
 		return -1;
@@ -186,28 +185,28 @@ recvMsg sendPayload(char *inData, int len){
 	- Output: recvMsg is received message
 Important note: inData is a string of hex (i.e., to send a byte of 0xAB, we need inData = {'A', 'B'})
 */
-int WISOL::sendPayload(uint8_t *outData, int len, int downlink, recvMsg *receivedMsg){
+int WISOL::sendPayload(uint8_t *outData, const uint8_t len, int downlink, recvMsg *receivedMsg){
 	int receivedResult;
 
-	if ((len > 12) | (len<=0)){
+	if ((len > 12) || (len <= 0)){
 		Serial.println("Payload length must be positive and not be longer than 12 bytes.");
 		clearBuffer();
 		return -1;
 	}
 
-	if (outData==NULL){
+	if (outData == NULL){
 		Serial.println("outData is NULL.");
 		clearBuffer();
 		return -1;
 	}
 
-	if ((downlink != 0) & (downlink != 1)){
+	if ((downlink != 0) || (downlink != 1)){
 		Serial.println("downlink must be 0 or 1.");
 		clearBuffer();
 		return -1;
 	}
 
-	if (receivedMsg==NULL){
+	if (receivedMsg == NULL){
 		Serial.println("receivedMsg is NULL.");
 		clearBuffer();
 		return -1;
@@ -226,22 +225,22 @@ recvMsg sendPayload(char *inData, int len){
 	- Output: recvMsg is received message
 Important note: inData is a string of hex (i.e., to send a byte of 0xAB, we need inData = {'A', 'B'})
 */
-int WISOL::sendPayload(uint8_t *outData, int len, int downlink){
+int WISOL::sendPayload(uint8_t *outData, const uint8_t len, int downlink){
 	int receivedResult;
 
-	if ((len > 12) | (len<=0)){
+	if ((len > 12) || (len <= 0)){
 		Serial.println("Payload length must be positive and not be longer than 12 bytes.");
 		clearBuffer();
 		return -1;
 	}
 
-	if (outData==NULL){
+	if (outData == NULL){
 		Serial.println("outData is NULL.");
 		clearBuffer();
 		return -1;
 	}
 
-	if ((downlink != 0) & (downlink != 1)){
+	if ((downlink != 0) || (downlink != 1)){
 		Serial.println("downlink must be 0 or 1.");
 		clearBuffer();
 		return -1;
@@ -253,22 +252,21 @@ int WISOL::sendPayload(uint8_t *outData, int len, int downlink){
 }
 
 
-
-int WISOL::sendPayloadProcess(uint8_t *outData, int len, int downlink, recvMsg *receivedMsg){
+int WISOL::sendPayloadProcess(uint8_t *outData, const uint8_t len, int downlink, recvMsg *receivedMsg){
 	static char header[] = "AT$SF=";
-	int headerLen = 6;
+	const uint8_t headerLen = (uint8_t) strlen(header);
 	int actualLen;
 	int sendLen;
 	char* hex_str;
 	int receivedResult;
 
-	if ((outData[len]=='\0') | (outData[len]=='\n')){
+	if ((outData[len] == '\0') || (outData[len] == '\n')){
 		actualLen = len - 1;
 	} else {
 		actualLen = len;
 	}
 
-	hex_str = (char*) malloc (2*actualLen);
+	hex_str = (char*) malloc (2 * actualLen);
 	ASCII2Hex(outData, actualLen, hex_str);
 	sendLen = 2*actualLen;
 
@@ -290,7 +288,7 @@ int WISOL::sendPayloadProcess(uint8_t *outData, int len, int downlink, recvMsg *
 		Serial.print(hex_str[i]); // print payload
 	}
 
-	if (downlink==1){
+	if (downlink == 1){
 		Serial.print(",1");
 	} else {
 
@@ -299,7 +297,7 @@ int WISOL::sendPayloadProcess(uint8_t *outData, int len, int downlink, recvMsg *
 	Serial.println('\n'); // send end terminal
 	free(hex_str); // free hex_str from the memory
 
-	if (receivedMsg!=NULL){
+	if (receivedMsg != NULL){
 		receivedResult = getRecvMsg(receivedMsg, downlink); // Read ACK
 	} else {
 		return 0; // No wait for ack
@@ -315,22 +313,22 @@ recvMsg sendMessage(char *inData, int len){
 	         len is the length of the sending message.
 	- Output: recvMsg is received message
 */
-int WISOL::sendMessage(char *outData, int len, recvMsg *receivedMsg){
+int WISOL::sendMessage(char *outData, const uint8_t len, recvMsg *receivedMsg){
 	int receivedResult;
 
-	if (len<=0){
+	if (len <= 0){
 		Serial.println("Payload length must be positive.");
 		clearBuffer();
 		return -1;
 	}
 
-	if (outData==NULL){
+	if (outData == NULL){
 		Serial.println("outData is NULL.");
 		clearBuffer();
 		return -1;
 	}
 
-	if (receivedMsg==NULL){
+	if (receivedMsg == NULL){
 		Serial.println("receivedMsg is NULL.");
 		clearBuffer();
 		return -1;
@@ -409,7 +407,7 @@ int WISOL::getRecvMsg(recvMsg *receivedMsg, int downlink){
 	}
 
 	// Wait for the incomming message
-	while (Serial.available()==0 && count <= countMax) {
+	while ((Serial.available() == 0) && (count <= countMax)) {
 		count++;
 		delay(100);
 	}
@@ -422,7 +420,7 @@ int WISOL::getRecvMsg(recvMsg *receivedMsg, int downlink){
 
 int WISOL::getdownlinkMsg(recvMsg *receivedMsg){
 
-	// Prepare receive messge format
+	// Prepare receive message format
 	receivedMsg->len = Serial.available();
 	receivedMsg->inData = master_receive;
 	if (receivedMsg->len){
@@ -446,8 +444,6 @@ int WISOL::getdownlinkMsg(recvMsg *receivedMsg){
 		return -1;
 	}
 	clearBuffer();
-
-
 }
 
 

--- a/libraries/Isigfox/WISOL.h
+++ b/libraries/Isigfox/WISOL.h
@@ -23,8 +23,8 @@ public:
     int initSigfox();
     void configIO(pinIO pin);
 	int testComms();
-	int sendPayload(uint8_t *outData, int len, int downlink, recvMsg *receivedMsg);
-	int sendPayload(uint8_t *outData, int len, int downlink);
+	int sendPayload(uint8_t *outData, const uint8_t len, int downlink, recvMsg *receivedMsg);
+	int sendPayload(uint8_t *outData, const uint8_t len, int downlink);
 	int sendMessage(char *outData, int len, recvMsg *receivedMsg);
 	int getdownlinkMsg(recvMsg *receivedMsg);
 	int getZone();
@@ -42,7 +42,7 @@ private:
 	void printRecv(char* in, int len);
 	void clearBuffer();
 	void ASCII2Hex(uint8_t* input, int length, char* buf_str);
-	int sendPayloadProcess(uint8_t *outData, int len, int downlink, recvMsg *receivedMsg);
+	int sendPayloadProcess(uint8_t *outData, const uint8_t len, int downlink, recvMsg *receivedMsg);
 	int getdownlinkMsg(int downlink, recvMsg *receivedMsg);
 
 	static const int BUFFER_SIZE = 40;


### PR DESCRIPTION
- Fixed typo in use of && and ||.
- Made some minor changes in use of data, made const to avoid be changed.
- Fixed the return value of some functions.